### PR TITLE
Fix region numbers

### DIFF
--- a/src/NosCore.Shared/Enumerations/RegionType.cs
+++ b/src/NosCore.Shared/Enumerations/RegionType.cs
@@ -17,8 +17,8 @@ namespace NosCore.Shared.Enumerations
         IT,
         PL,
         ES,
-        CS,
-        TR,
-        RU
+        RU,
+        CZ,
+        TR
     }
 }

--- a/src/NosCore.Shared/Enumerations/RegionType.cs
+++ b/src/NosCore.Shared/Enumerations/RegionType.cs
@@ -18,7 +18,7 @@ namespace NosCore.Shared.Enumerations
         PL,
         ES,
         RU,
-        CZ,
+        CS,
         TR
     }
 }


### PR DESCRIPTION
The region numbers are in wrong order.
Gfclient opens process "NostaleClientX.exe gf X" where X is the code of the region.
If you check process command line you can clearly see that RU is 6, CZ is 7 and TR is 8.
Numbers 0 - 5 are all correct.
