### PR TITLE
ci: grant contents:write for release asset upload

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET


### PR DESCRIPTION
Same fix as NosCore.Packets#441 and NosCore.ParserInputGenerator. Ensures GITHUB_TOKEN has release-write scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to improve automated release publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->