### PR TITLE
chore: support local NuGet source via NOSCORE_LOCAL_PACKAGES env var

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup Condition="'$(NOSCORE_LOCAL_PACKAGES)' != ''">
+    <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources);$(NOSCORE_LOCAL_PACKAGES)</RestoreAdditionalProjectSources>
+  </PropertyGroup>
+</Project>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <packageSources>
-        <add key="local" value="%NOSCORE_LOCAL_PACKAGES%" />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     </packageSources>
 </configuration>


### PR DESCRIPTION
## Summary
- Adds `Directory.Build.props` with a conditional `RestoreAdditionalProjectSources` that activates only when `NOSCORE_LOCAL_PACKAGES` is set.
- No runtime cost for contributors who don't opt in — the property group is skipped, restore uses nuget.org only.
- To use: `setx NOSCORE_LOCAL_PACKAGES C:\LocalPackages`, restart shell/VS, drop .nupkg files into the folder. Replaces the earlier `NuGet.config`-based attempt, which broke restore (NU1301) whenever the env var was unset.

## Test plan
- [ ] `dotnet restore` succeeds with `NOSCORE_LOCAL_PACKAGES` unset.
- [ ] `dotnet restore` with `NOSCORE_LOCAL_PACKAGES` pointing to a folder with a .nupkg picks it up.

Generated with [Claude Code](https://claude.com/claude-code)